### PR TITLE
Target main instead of master with GitHub Actions publish workflow

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -1,7 +1,7 @@
 name: Publish Workflow
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
**Changes:**

- Target `main` instead of `master` branch with GitHub Actions publish workflow
