### PR TITLE
Add the missing `--access public` flag to the `npm publish` command so package publishing isn't rejected

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -24,6 +24,6 @@ jobs:
       - uses: mangs/simple-release-notes-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - run: npm publish
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_USER_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.3
+
+- Add the missing `--access public` flag to the `npm publish` command so package publishing isn't rejected
+
 ## 2.0.2
 
 - Enable publishing to the NPM registry

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babbel/rollbar-client.js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babbel/rollbar-client.js",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "bundleDependencies": [
         "error-stack-parser",
         "just-extend"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/rollbar-client.js",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Tiny, modern Rollbar TypeScript client whose code is mostly lazy-loaded if and when an error occurs",
   "engines": {


### PR DESCRIPTION
**Changes:**

- Version bump to `2.0.3`
- Add the missing `--access public` flag to the `npm publish` command so package publishing isn't rejected