### PR TITLE
Update publishWorkflow.yml

### DIFF
--- a/.github/workflows/publishWorkflow.yml
+++ b/.github/workflows/publishWorkflow.yml
@@ -11,18 +11,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18.16.1"
           registry-url: https://registry.npmjs.org
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-region: ${{ vars.AWS_REGION }}
-          role-to-assume: ${{ vars.AWS_IAM_ROLE_ARN }}
-      - uses: aws-actions/aws-secretsmanager-get-secrets@v2
-        with:
-          parse-json-secrets: true
-          secret-ids: NPM_USER,${{ vars.NPM_USER_SECRET_ARN }}
       - id: super-cache
         uses: mangs/super-cache-action@v3
       - if: steps.super-cache.outputs.cache-hit != 'true'
@@ -35,6 +27,5 @@ jobs:
       - uses: mangs/simple-release-notes-action@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      # authenticate by OIDC
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ env.NPM_USER_ACCESS_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.2
+
+- Updated publish workflow to use OIDC.
+
 ## 2.1.1
 
 - Updated publish workflow's way of retrieving secrets

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@babbel/rollbar-client.js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@babbel/rollbar-client.js",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "bundleDependencies": [
         "error-stack-parser",
         "just-extend"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@babbel/rollbar-client.js",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": "Eric L. Goldstein <egoldstein@babbel.com>",
   "description": "Tiny, modern Rollbar TypeScript client whose code is mostly lazy-loaded if and when an error occurs",
   "license": "MIT",


### PR DESCRIPTION
**Changes:** Change publish workflow to use OIDC

We would like to use trusted publishing because otherwise we need to periodically rotate the secrets.

This PR introduces publishing to npmjs.org using OIDC as [documented here](https://docs.npmjs.com/trusted-publishers#prefer-trusted-publishing-over-tokens).

## Depends-on 
- [x] enable GitHub/npm OIDC trust in [npm package settings](https://www.npmjs.com/package/@babbel/rollbar-client.js/access) (requires admin permissions)

<img width="836" height="422" alt="Screenshot 2025-12-18 at 16 27 34" src="https://github.com/user-attachments/assets/eba37e6d-9898-4105-9aa6-78f2303d50d3" />