### PR TITLE
handle unparseable stack trace better

### DIFF
--- a/src/RollbarClientSubmitter.mts
+++ b/src/RollbarClientSubmitter.mts
@@ -47,12 +47,16 @@ function buildObjectDeepSorted<T extends object>(targetValue: T): T {
 }
 
 function getStackFrames(error: Error) {
-  return ErrorStackParser.parse(error).map((frame) => ({
-    colno: frame.columnNumber,
-    filename: frame.fileName,
-    lineno: frame.lineNumber,
-    method: frame.functionName,
-  }));
+  try {
+    return ErrorStackParser.parse(error).map((frame) => ({
+      colno: frame.columnNumber,
+      filename: frame.fileName,
+      lineno: frame.lineNumber,
+      method: frame.functionName,
+    }));
+  } catch {
+    return [];
+  }
 }
 
 function logToConsole(...parameters: TSubmitterParameters) {

--- a/src/RollbarClientSubmitter.test.mts
+++ b/src/RollbarClientSubmitter.test.mts
@@ -425,6 +425,35 @@ describe(`Class: ${RollbarClientSubmitter.name}`, () => {
 
           expect(actualLibraryVersion).toBe(expectedlibraryVersion);
         });
+
+        test('error object with non-parseable stack trace passed', async () => {
+          const testErrorMessage = 'test error';
+          const testError = new TypeError(testErrorMessage);
+          const testMessage = 'test message';
+          delete testError.stack;
+          await submitter.report('error', testMessage, testError);
+
+          const payload = buildMinimalPayload();
+          payload.data.body = {
+            trace: {
+              exception: {
+                class: 'TypeError',
+                description: testMessage,
+                message: testErrorMessage,
+                raw: String(testError),
+                stack: testError.stack,
+              },
+              frames: [],
+            },
+          };
+          payload.data.custom = {
+            ...payload.data.custom,
+          };
+
+          expect(window.fetch).toHaveBeenCalledTimes(0);
+          expect(navigator.sendBeacon).toHaveBeenCalledTimes(1);
+          expect(navigator.sendBeacon).toHaveBeenCalledWith(defaultApiUrl, JSON.stringify(payload));
+        });
       });
 
       describe('Configuration options', () => {


### PR DESCRIPTION
We are receiving rollbar errors caused by unhandled promise rejections originating from the library.

The issue seems to be some errors we are sending in do not have a stack trace (or at least a stack trace considered valid from the perspective of the error-stack-parser library, so we receive [this error](https://github.com/stacktracejs/error-stack-parser/blob/9f33c224b5d7b607755eb277f9d51fcdb7287e24/error-stack-parser.js#L35).

This is not ideal as it adds unactionnable noise and we don't know what error we sent in caused the problem.

This PR proposes to avoid throwing errors and letting the errors be reported with empty stack frames.

**Changes:**

- Avoid throwing if the stack trace isn't parseable